### PR TITLE
Update image build tag to latest

### DIFF
--- a/datahub/values.yaml
+++ b/datahub/values.yaml
@@ -1,7 +1,8 @@
 replicaCount: 1
 
 image:
-  # check the oficial image tags to see witch is one you need
+  # Check the official image tags to see which is one you need
+  # https://hub.docker.com/r/geonetwork/geonetwork-ui-datahub/tags
   repository: geonetwork/geonetwork-ui-datahub
   tag: latest
   pullPolicy: Always

--- a/datahub/values.yaml
+++ b/datahub/values.yaml
@@ -1,8 +1,9 @@
 replicaCount: 1
 
 image:
+  # check the oficial image tags to see witch is one you need
   repository: geonetwork/geonetwork-ui-datahub
-  tag: master
+  tag: latest
   pullPolicy: Always
 
 configuration:


### PR DESCRIPTION
As requested on  #13 , this is a minor change to the values.yaml: 

- Update the image tag to get the latest build, since the previous 'master'  was two years old and missing serveral important things like the wc-embedder.html file;