### PR TITLE
feat: update chart to deploy 2.6.0 version of the DH

### DIFF
--- a/datahub/Chart.yaml
+++ b/datahub/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: datahub
 description: A Helm chart to deploy the datahub application
 type: application
-version: 1.1.1
-appVersion: "1.16.0"
+version: 1.2.0
+appVersion: "2.6.0"
 maintainers:
-  - name: geOrchestra
-    url: https://www.georchestra.org
+  - name: geonetwork-ui
+    url: https://geonetwork.github.io/geonetwork-ui/main/docs/

--- a/datahub/README.md
+++ b/datahub/README.md
@@ -78,6 +78,10 @@ You can also configure some options using the environment variables like `GN4_AP
 
 ## Changelog
 
+### Version 1.2.0
+
+Bump datahub to version 2.6.0.
+
 ### Version 0.4.1
 
 Fixing ingress support

--- a/datahub/values.yaml
+++ b/datahub/values.yaml
@@ -4,7 +4,7 @@ image:
   # Check the official image tags to see which is one you need
   # https://hub.docker.com/r/geonetwork/geonetwork-ui-datahub/tags
   repository: geonetwork/geonetwork-ui-datahub
-  tag: 2.5.0
+  tag: 2.6.0
   pullPolicy: IfNotPresent
 
 configuration:
@@ -32,7 +32,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - mydatahub.org
-  
+
   # define a custom incressClassName, like "traefik" or "nginx"
   className: ""
 


### PR DESCRIPTION
Update the datahub helm chart to deploy the last (2.6.0) version of the DataHub, which has been released yesterday.

Note: I allowed myself to change the appVersion in the chart yaml file, so that it reflects the version actually being deployed, but not sure if it makes more sense, I was confused by the 1.16.0, not being able to figure out to what it was referring to.

Note2: Also updated the maintainer part to point to geonetwork-ui instead of georchestra.

Note3: Added an entry to the README.md's changelog, but it does not seem to be updated at each releases.

Tests: `helm template` ok, the image being referenced in the deployment exists / `docker pull` successful.