### PR TITLE
chore: add ability to configure docker image used for datadir init

### DIFF
--- a/datahub/Chart.yaml
+++ b/datahub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub
 description: A Helm chart to deploy the datahub application
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "2.6.0"
 maintainers:
   - name: geonetwork-ui

--- a/datahub/templates/_bootstrap-datahub-configuration.tpl
+++ b/datahub/templates/_bootstrap-datahub-configuration.tpl
@@ -1,6 +1,6 @@
 {{- define "datahub.bootstrap_datahub_configuration" -}}
 - name: bootstrap-datahub-configuration
-  image: bitnami/git
+  image: "{{ .Values.configuration.image.repository }}:{{ .Values.configuration.image.tag }}"
   command:
   - /bin/sh
   - -c

--- a/datahub/values.yaml
+++ b/datahub/values.yaml
@@ -8,6 +8,9 @@ image:
   pullPolicy: IfNotPresent
 
 configuration:
+  image:
+    repository: bitnami/git
+    tag: 2
   # The directory name is the directory from the root of the git repository
   # If the datahub config is located in the /conf directory then write conf
   # in config_directory_override.

--- a/metadata-editor/Chart.yaml
+++ b/metadata-editor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metadata-editor
 description: A Helm chart to deploy the metadata-editor application
 type: application
-version: 1.1.1
+version: 1.2.0
 appVersion: "1.0.0"
 maintainers:
   - name: geOrchestra

--- a/metadata-editor/templates/_bootstrap-metadata-editor-configuration.tpl
+++ b/metadata-editor/templates/_bootstrap-metadata-editor-configuration.tpl
@@ -1,6 +1,6 @@
 {{- define "metadata-editor.bootstrap_metadata-editor_configuration" -}}
 - name: bootstrap-metadata-editor-configuration
-  image: bitnami/git
+  image: "{{ .Values.configuration.image.repository }}:{{ .Values.configuration.image.tag }}"
   command:
   - /bin/sh
   - -c

--- a/metadata-editor/values.yaml
+++ b/metadata-editor/values.yaml
@@ -6,6 +6,9 @@ image:
   pullPolicy: IfNotPresent
 
 configuration:
+  image:
+    repository: bitnami/git
+    tag: 2
   # The directory name is the directory from the root of the git repository
   # If the metadata-editor config is located in the /conf directory then write conf
   # in config_directory_override.


### PR DESCRIPTION
In certain scenario, you may need to customize the bitnami/git image used.

- Because you are in a restricted environment that use a registry proxy.
- Because you want to use a proxy in order to not be affected by Docker hub limits.